### PR TITLE
Add higher arity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 flamegraph.svg
+/logs
+/scripts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ p3-sha256 = { path = "sha256", version = "0.1.0" }
 p3-symmetric = { path = "symmetric", version = "0.1.0" }
 p3-uni-stark = { path = "uni-stark", version = "0.1.0" }
 p3-util = { path = "util", version = "0.1.0" }
+bincode = "1.3.3"
 
 [profile.profiling]
 inherits = "release"

--- a/blake3-air/examples/prove_blake3_koala_bear_keccak.rs
+++ b/blake3-air/examples/prove_blake3_koala_bear_keccak.rs
@@ -55,6 +55,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/circle/src/folding.rs
+++ b/circle/src/folding.rs
@@ -37,13 +37,14 @@ impl<F: ComplexExtendable, EF: ExtensionField<F>, InputProof, InputError: Debug>
         &self,
         index: usize,
         log_folded_height: usize,
+        _num_folds: usize,
         beta: EF,
-        evals: impl Iterator<Item = EF>,
+        evals: Vec<EF>,
     ) -> EF {
         fold_x_row(index, log_folded_height, beta, evals)
     }
 
-    fn fold_matrix<M: Matrix<EF>>(&self, beta: EF, m: M) -> Vec<EF> {
+    fn fold_matrix<M: Matrix<EF>>(&self, beta: EF, m: M, _num_folds: usize) -> Vec<EF> {
         fold_x(beta, m)
     }
 }
@@ -112,9 +113,8 @@ pub(crate) fn fold_x_row<F: ComplexExtendable, EF: ExtensionField<F>>(
     index: usize,
     log_folded_height: usize,
     beta: EF,
-    evals: impl Iterator<Item = EF>,
+    evals: Vec<EF>,
 ) -> EF {
-    let evals = evals.collect_vec();
     assert_eq!(evals.len(), 2);
     let log_arity = log2_strict_usize(evals.len());
 
@@ -155,7 +155,7 @@ mod tests {
 
         let mat_x_folded = fold_x::<F, EF>(beta, m.as_view());
         let row_x_folded = (0..(1 << log_folded_height))
-            .map(|i| fold_x_row::<F, EF>(i, log_folded_height, beta, m.row(i)))
+            .map(|i| fold_x_row::<F, EF>(i, log_folded_height, beta, m.row(i).collect()))
             .collect_vec();
         assert_eq!(mat_x_folded, row_x_folded);
     }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -511,6 +511,7 @@ mod tests {
         type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
         let fri_config = FriConfig {
+            log_arity: 1,
             log_blowup: 1,
             num_queries: 2,
             proof_of_work_bits: 1,

--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -95,7 +95,7 @@ where
         let beta: Challenge = challenger.sample_ext_element();
         // We passed ownership of `current` to the MMCS, so get a reference to it
         let leaves = config.mmcs.get_matrices(&prover_data).pop().unwrap();
-        folded = g.fold_matrix(beta, leaves.as_view());
+        folded = g.fold_matrix(beta, leaves.as_view(), 1);
 
         commits.push(commit);
         data.push(prover_data);

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -126,7 +126,7 @@ where
 
         index = index_pair;
 
-        folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
+        folded_eval = g.fold_row(index, log_folded_height, 1, beta, evals);
     }
 
     debug_assert!(index < config.blowup(), "index was {}", index);

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -31,7 +31,16 @@ p3-poseidon2.workspace = true
 p3-symmetric.workspace = true
 criterion.workspace = true
 rand_chacha.workspace = true
+bincode.workspace = true
 
 [[bench]]
 name = "fold_even_odd"
+harness = false
+
+[[bench]]
+name = "fold_high_arity"
+harness = false
+
+[[bench]]
+name = "fri"
 harness = false

--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -1,45 +1,49 @@
-use std::any::type_name;
-
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use p3_baby_bear::BabyBear;
 use p3_field::extension::Complex;
 use p3_field::TwoAdicField;
 use p3_fri::fold_even_odd;
 use p3_goldilocks::Goldilocks;
+use p3_matrix::dense::RowMajorMatrix;
 use p3_mersenne_31::Mersenne31;
 use rand::distributions::{Distribution, Standard};
 use rand::{thread_rng, Rng};
 
-fn bench<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize])
+fn bench<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize], field_name: &'static str)
 where
     Standard: Distribution<F>,
 {
-    let name = format!("fold_even_odd::<{}>", type_name::<F>(),);
+    let name = format!("fold_even_odd::<{}>", field_name,);
     let mut group = c.benchmark_group(&name);
     group.sample_size(10);
 
     for log_size in log_sizes {
         let n = 1 << log_size;
 
-        let mut rng = thread_rng();
-        let beta = rng.sample(Standard);
-        let poly = rng.sample_iter(Standard).take(n).collect_vec();
-
-        group.bench_function(BenchmarkId::from_parameter(n), |b| {
-            b.iter(|| {
-                fold_even_odd(poly.clone(), beta);
-            })
+        group.bench_function(format!("({})", log_size), |b| {
+            b.iter_with_setup(
+                || {
+                    let mut rng = thread_rng();
+                    let beta = rng.sample(Standard);
+                    let poly = rng.sample_iter(Standard).take(n).collect_vec();
+                    let poly = RowMajorMatrix::new(poly, 2);
+                    (poly, beta)
+                },
+                |(poly, beta)| {
+                    fold_even_odd(poly, beta);
+                },
+            )
         });
     }
 }
 
 fn bench_fold_even_odd(c: &mut Criterion) {
-    let log_sizes = [12, 14, 16, 18, 20, 22];
+    let log_sizes = [20, 24];
 
-    bench::<BabyBear>(c, &log_sizes);
-    bench::<Goldilocks>(c, &log_sizes);
-    bench::<Complex<Mersenne31>>(c, &log_sizes);
+    bench::<BabyBear>(c, &log_sizes, "BabyBear");
+    bench::<Goldilocks>(c, &log_sizes, "Goldilocks");
+    bench::<Complex<Mersenne31>>(c, &log_sizes, "Complex<Mersenne31>");
 }
 
 criterion_group!(benches, bench_fold_even_odd);

--- a/fri/benches/fold_high_arity.rs
+++ b/fri/benches/fold_high_arity.rs
@@ -1,0 +1,60 @@
+use std::marker::PhantomData;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+use p3_baby_bear::BabyBear;
+use p3_field::extension::Complex;
+use p3_field::TwoAdicField;
+use p3_fri::{FriGenericConfig, TwoAdicFriGenericConfig};
+use p3_goldilocks::Goldilocks;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_mersenne_31::Mersenne31;
+use rand::distributions::{Distribution, Standard};
+use rand::{thread_rng, Rng};
+
+fn bench<F: TwoAdicField>(
+    c: &mut Criterion,
+    log_sizes: &[usize],
+    log_arities: &[usize],
+    field_name: &'static str,
+) where
+    Standard: Distribution<F>,
+{
+    let name = format!("fold::<{}>", field_name,);
+    let mut group = c.benchmark_group(&name);
+    group.sample_size(10);
+    let g: TwoAdicFriGenericConfig<(), ()> = TwoAdicFriGenericConfig(PhantomData);
+
+    for log_size in log_sizes {
+        for log_arity in log_arities {
+            let n = 1 << log_size;
+
+            group.bench_function(format!("({}, {})", log_size, log_arity), |b| {
+                b.iter_with_setup(
+                    || {
+                        let mut rng = thread_rng();
+                        let beta = rng.sample(Standard);
+                        let poly = rng.sample_iter(Standard).take(n).collect_vec();
+                        let poly = RowMajorMatrix::new(poly, 1 << log_arity);
+                        (poly, beta)
+                    },
+                    |(poly, beta)| {
+                        g.fold_matrix(beta, poly, *log_arity);
+                    },
+                )
+            });
+        }
+    }
+}
+
+fn bench_fold_high_arity(c: &mut Criterion) {
+    let log_sizes = [20, 24];
+    let log_arities = [1, 2, 4];
+
+    bench::<BabyBear>(c, &log_sizes, &log_arities, "BabyBear");
+    bench::<Goldilocks>(c, &log_sizes, &log_arities, "Goldilocks");
+    bench::<Complex<Mersenne31>>(c, &log_sizes, &log_arities, "Complex_Mersenne31");
+}
+
+criterion_group!(benches, bench_fold_high_arity);
+criterion_main!(benches);

--- a/fri/benches/fri.rs
+++ b/fri/benches/fri.rs
@@ -1,0 +1,232 @@
+use core::cmp::Reverse;
+use std::array;
+use std::marker::PhantomData;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::{DuplexChallenger, FieldChallenger, GrindingChallenger};
+use p3_commit::ExtensionMmcs;
+use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, FieldAlgebra};
+use p3_fri::{prover, verifier, FriConfig, FriProof, TwoAdicFriGenericConfig};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::util::reverse_matrix_index_bits;
+use p3_matrix::Matrix;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_util::log2_strict_usize;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+
+type Val = BabyBear;
+type Challenge = BinomialExtensionField<Val, 4>;
+
+type Perm = Poseidon2BabyBear<16>;
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+type ValMmcs =
+    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+type MyFriConfig = FriConfig<ChallengeMmcs>;
+
+fn get_ldt_for_testing<R: Rng>(
+    rng: &mut R,
+    log_blowup: usize,
+    log_arity: usize,
+) -> (Perm, MyFriConfig) {
+    let perm = Perm::new_from_rng_128(rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));
+    let fri_config = FriConfig {
+        log_blowup,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs,
+        log_arity,
+    };
+    (perm, fri_config)
+}
+
+fn fri_setup<const N: usize>(
+    test_shapes: [i32; N],
+    log_blowup: usize,
+    log_arity: usize,
+) -> (
+    MyFriConfig,
+    Vec<Vec<Challenge>>,
+    (Challenger, Challenger),
+    usize,
+) {
+    let rng = &mut ChaCha20Rng::seed_from_u64(0);
+    let (perm, fc) = get_ldt_for_testing(rng, log_blowup, log_arity);
+    let dft = Radix2Dit::default();
+
+    let shift = Val::GENERATOR;
+
+    let ldes: Vec<RowMajorMatrix<Val>> = test_shapes
+        .iter()
+        .map(|deg_bits| {
+            let evals = RowMajorMatrix::<Val>::rand_nonzero(rng, 1 << deg_bits, 1);
+            let mut lde = dft.coset_lde_batch(evals, log_blowup, shift);
+            reverse_matrix_index_bits(&mut lde);
+            lde
+        })
+        .collect();
+
+    // Prover world
+    let mut p_challenger = Challenger::new(perm.clone());
+    let alpha: Challenge = p_challenger.sample_ext_element();
+
+    let input: [_; 32] = core::array::from_fn(|log_height| {
+        let matrices_with_log_height: Vec<&RowMajorMatrix<Val>> = ldes
+            .iter()
+            .filter(|m| log2_strict_usize(m.height()) == log_height)
+            .collect();
+        if matrices_with_log_height.is_empty() {
+            None
+        } else {
+            let reduced: Vec<Challenge> = (0..(1 << log_height))
+                .map(|r| {
+                    alpha
+                        .powers()
+                        .zip(matrices_with_log_height.iter().flat_map(|m| m.row(r)))
+                        .map(|(alpha_pow, v)| alpha_pow * v)
+                        .sum()
+                })
+                .collect();
+            Some(reduced)
+        }
+    });
+
+    let input: Vec<Vec<Challenge>> = input.into_iter().rev().flatten().collect();
+
+    let log_max_height = log2_strict_usize(input[0].len());
+
+    let mut v_challenger = Challenger::new(perm);
+    let _alpha: Challenge = v_challenger.sample_ext_element();
+
+    (fc, input, (p_challenger, v_challenger), log_max_height)
+}
+
+fn fri_prove(
+    fc: &MyFriConfig,
+    input: Vec<Vec<Challenge>>,
+    mut chal: Challenger,
+    log_max_height: usize,
+) -> FriProof<
+    Challenge,
+    ChallengeMmcs,
+    <Challenger as GrindingChallenger>::Witness,
+    Vec<(usize, Challenge)>,
+> {
+    prover::prove(
+        &TwoAdicFriGenericConfig::<Vec<(usize, Challenge)>, ()>(PhantomData),
+        fc,
+        input.clone(),
+        &mut chal,
+        |idx| {
+            // As our "input opening proof", just pass through the literal reduced openings.
+            let mut ro = vec![];
+            for v in &input {
+                let log_height = log2_strict_usize(v.len());
+                ro.push((log_height, v[idx >> (log_max_height - log_height)]));
+            }
+            ro.sort_by_key(|(lh, _)| Reverse(*lh));
+            ro
+        },
+    )
+}
+
+fn bench_fri(c: &mut Criterion) {
+    // FRI is kind of flaky depending on indexing luck
+    let mut group = c.benchmark_group("fri");
+    group.sample_size(10);
+    let test_shape_start = 20;
+    const TEST_SHAPE_LEN: usize = 5;
+    let log_blowup = 1;
+
+    for log_step_by in 0..3 {
+        let mut test_shapes: [_; TEST_SHAPE_LEN] =
+            array::from_fn(|step| test_shape_start - (step << log_step_by) as i32);
+        test_shapes.reverse();
+        for log_arity in [1usize, 2, 4] {
+            group.bench_function(
+                format!(
+                    "prove/test_shapes={:?}/log_arity={}",
+                    test_shapes, log_arity
+                ),
+                |b| {
+                    b.iter_with_setup(
+                        || fri_setup(test_shapes, log_blowup, log_arity),
+                        |(fc, input, (p_challenger, _), log_max_height)| {
+                            let _ = black_box(fri_prove(&fc, input, p_challenger, log_max_height));
+                        },
+                    )
+                },
+            );
+        }
+    }
+
+    for log_step_by in 0..3 {
+        let mut test_shapes: [_; TEST_SHAPE_LEN] =
+            array::from_fn(|step| test_shape_start - (step << log_step_by) as i32);
+        test_shapes.reverse();
+        for log_arity in [1usize, 2, 4] {
+            group.bench_function(
+                format!(
+                    "verify/test_shapes={:?}/log_arity={}",
+                    test_shapes, log_arity
+                ),
+                |b| {
+                    b.iter_with_setup(
+                        || {
+                            let (fc, input, (p_challenger, v_challenger), log_max_height) =
+                                fri_setup(test_shapes, log_blowup, log_arity);
+                            let proof = fri_prove(&fc, input, p_challenger, log_max_height);
+
+                            (fc, proof, v_challenger)
+                        },
+                        |(fc, proof, mut v_challenger)| {
+                            verifier::verify(
+                                &TwoAdicFriGenericConfig::<Vec<(usize, Challenge)>, ()>(
+                                    PhantomData,
+                                ),
+                                &fc,
+                                &proof,
+                                &mut v_challenger,
+                                |_index, proof| Ok(proof.clone()),
+                            )
+                            .unwrap();
+                        },
+                    )
+                },
+            );
+        }
+    }
+
+    for log_step_by in 0..3 {
+        let mut test_shapes: [_; TEST_SHAPE_LEN] =
+            array::from_fn(|step| test_shape_start - (step << log_step_by) as i32);
+        test_shapes.reverse();
+        for log_arity in [1usize, 2, 4] {
+            let (fc, input, (p_challenger, _v_challenger), log_max_height) =
+                fri_setup(test_shapes, log_blowup, log_arity);
+            let proof = fri_prove(&fc, input, p_challenger, log_max_height);
+            let proof_size = bincode::serialize(&proof).unwrap().len();
+            println!(
+                "fri/proof_size/test_shapes={:?}/log_arity={}:   proofsize:   [{:.2} KB {:.2} KB {:.2} KB]",
+                test_shapes,
+                log_arity,
+                proof_size as f64 / 1024.0,
+                proof_size as f64 / 1024.0,
+                proof_size as f64 / 1024.0,
+            );
+        }
+    }
+}
+
+criterion_group!(benches, bench_fri);
+criterion_main!(benches);

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -7,6 +7,7 @@ use p3_matrix::Matrix;
 #[derive(Debug)]
 pub struct FriConfig<M> {
     pub log_blowup: usize,
+    pub log_arity: usize,
     pub num_queries: usize,
     pub proof_of_work_bits: usize,
     pub mmcs: M,
@@ -15,6 +16,10 @@ pub struct FriConfig<M> {
 impl<M> FriConfig<M> {
     pub const fn blowup(&self) -> usize {
         1 << self.log_blowup
+    }
+
+    pub const fn arity(&self) -> usize {
+        1 << self.log_arity
     }
 
     /// Returns the soundness bits of this FRI instance based on the
@@ -44,10 +49,11 @@ pub trait FriGenericConfig<F: Field> {
         &self,
         index: usize,
         log_height: usize,
+        num_folds: usize,
         beta: F,
-        evals: impl Iterator<Item = F>,
+        evals: Vec<F>,
     ) -> F;
 
     /// Same as applying fold_row to every row, possibly faster.
-    fn fold_matrix<M: Matrix<F>>(&self, beta: F, m: M) -> Vec<F>;
+    fn fold_matrix<M: Matrix<F>>(&self, beta: F, m: M, num_folds: usize) -> Vec<F>;
 }

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -1,8 +1,7 @@
 use alloc::vec::Vec;
 
-use itertools::Itertools;
+use itertools::{izip, Itertools};
 use p3_field::TwoAdicField;
-use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
@@ -18,7 +17,8 @@ use tracing::instrument;
 /// ```
 /// Expects input to be bit-reversed evaluations.
 #[instrument(skip_all, level = "debug")]
-pub fn fold_even_odd<F: TwoAdicField>(poly: Vec<F>, beta: F) -> Vec<F> {
+pub fn fold_even_odd<M: Matrix<F>, F: TwoAdicField>(m: M, beta: F) -> Vec<F> {
+    assert_eq!(m.width(), 2);
     // We use the fact that
     //     p_e(x^2) = (p(x) + p(-x)) / 2
     //     p_o(x^2) = (p(x) - p(-x)) / (2 x)
@@ -29,7 +29,6 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: Vec<F>, beta: F) -> Vec<F> {
     //     result(g^(2i)) = p_e(g^(2i)) + beta p_o(g^(2i))
     //                    = (1/2 + beta/2 g_inv^i) p(g^i)
     //                    + (1/2 - beta/2 g_inv^i) p(g^(n/2 + i))
-    let m = RowMajorMatrix::new(poly, 2);
     let g_inv = F::two_adic_generator(log2_strict_usize(m.height()) + 1).inverse();
     let one_half = F::TWO.inverse();
     let half_beta = beta * one_half;
@@ -52,11 +51,71 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: Vec<F>, beta: F) -> Vec<F> {
         .collect()
 }
 
+/// Fold a polynomial by an arity higher than 2.
+pub fn fold<M: Matrix<F>, F: TwoAdicField>(m: M, beta: F, log_arity: usize) -> Vec<F> {
+    assert_eq!(m.width(), 1 << log_arity);
+    // Let h = 2^log_arity. Write a polynomial p(x) as sum_{i=0}^{h-1} x^i p_i(x^h).
+    // We seek a vector of evaluations of the polynomial p'(x) = sum_{i=1}^{h-1} beta^i p_i(x), given
+    // evaluations of p(x).
+    //
+    // Let z be an h-th root of unity. We use the formula:
+    // p_j(x) = 1/(h x^j) sum_{k=0}^{h-1} z^{-i*j}p(z^i*x), which is basically an inverse Fourier transform.
+    // Plugging this in to the expression for p'(x) gives:
+    // p'(x) = sum_{i,j=1}^{h-1} beta^i p(z^i * x) * beta^j * z^{-i*j} / (h x^j).
+
+    let g_inv = F::two_adic_generator(log2_strict_usize(m.height()) + log_arity).inverse();
+    let normalizing_factor = F::from_canonical_u32(1 << log_arity).inverse();
+
+    // TODO: vectorize this (after we have packed extension fields)
+
+    // successive powers of g_inv
+    let mut g_powers = g_inv.powers().take(m.height()).collect_vec();
+    reverse_slice_index_bits(&mut g_powers);
+
+    let root_of_unity = F::two_adic_generator(log_arity);
+    let mut roots_of_unity = root_of_unity
+        .inverse()
+        .powers()
+        .take(1 << log_arity)
+        .collect_vec();
+    reverse_slice_index_bits(&mut roots_of_unity);
+
+    let half_coeffs = roots_of_unity
+        .iter()
+        .map(|root| {
+            izip!(beta.powers().take(1 << (log_arity - 1)), root.powers(),)
+                .map(|(a, b)| normalizing_factor * a * b)
+                .collect_vec()
+        })
+        .collect_vec();
+
+    let beta_shift = beta.exp_power_of_2(log_arity - 1);
+    m.par_rows()
+        .zip(g_powers)
+        .map(|(row, power)| {
+            let shift_even = F::ONE + beta_shift * power.exp_power_of_2(log_arity - 1);
+            let shift_odd = F::TWO - shift_even;
+            row.zip(half_coeffs.iter().enumerate())
+                .map(|(r, (i, coeff))| {
+                    let x = if i >> (log_arity - 1) & 1 == 0 {
+                        shift_even
+                    } else {
+                        shift_odd
+                    };
+                    r * x * izip!(coeff, power.powers()).map(|(a, b)| *a * b).sum()
+                })
+                .sum()
+        })
+        .collect::<Vec<_>>()
+}
+
 #[cfg(test)]
 mod tests {
     use itertools::izip;
     use p3_baby_bear::BabyBear;
     use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
+    use p3_field::FieldAlgebra;
+    use p3_matrix::dense::RowMajorMatrix;
     use rand::{thread_rng, Rng};
 
     use super::*;
@@ -88,9 +147,41 @@ mod tests {
         // fold_even_odd takes and returns in bitrev order.
         let mut folded = evals;
         reverse_slice_index_bits(&mut folded);
-        folded = fold_even_odd(folded, beta);
+        let m = RowMajorMatrix::new(folded, 2);
+        folded = fold_even_odd(m, beta);
         reverse_slice_index_bits(&mut folded);
 
         assert_eq!(expected, folded);
+    }
+
+    #[test]
+    fn test_higher_arity_fold() {
+        type F = BabyBear;
+
+        let mut rng = thread_rng();
+
+        let log_arity = 4;
+        let log_n = 12;
+        let n = 1 << log_n;
+        let coeffs = (0..n).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
+
+        let dft = Radix2Dit::default();
+        let evals = dft.dft(coeffs.clone());
+
+        let beta = rng.gen::<F>();
+        let mut result = evals.clone();
+        let mut new_beta = beta;
+        for _ in 0..log_arity {
+            let m = RowMajorMatrix::new(result, 2);
+            result = fold_even_odd(m, new_beta);
+            new_beta = new_beta.square();
+        }
+
+        let m = RowMajorMatrix::new(evals, 1 << log_arity);
+        let folded = fold(m, beta, log_arity);
+
+        assert_eq!(result.len(), folded.len());
+
+        assert_eq!(result, folded);
     }
 }

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -1,11 +1,16 @@
 use alloc::vec::Vec;
 
-use itertools::{izip, Itertools};
+use itertools::Itertools;
 use p3_field::TwoAdicField;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 use tracing::instrument;
+
+#[inline]
+pub fn fold_row_binary<F: TwoAdicField>(r0: F, r1: F, shifted_g_inv_power: F, one_half: F) -> F {
+    (one_half + shifted_g_inv_power) * r0 + (one_half - shifted_g_inv_power) * r1
+}
 
 /// Fold a polynomial
 /// ```ignore
@@ -46,12 +51,99 @@ pub fn fold_even_odd<M: Matrix<F>, F: TwoAdicField>(m: M, beta: F) -> Vec<F> {
         .zip(powers)
         .map(|(mut row, power)| {
             let (r0, r1) = row.next_tuple().unwrap();
-            (one_half + power) * r0 + (one_half - power) * r1
+            fold_row_binary(r0, r1, power, one_half)
         })
         .collect()
 }
 
+pub fn fold_row_quad<F: TwoAdicField>(
+    evals: &[F],
+    roots_of_unity_inv: &[F],
+    g_inv_power: F,
+    beta: F,
+    normalizing_factor: F,
+) -> F {
+    let beta = beta * g_inv_power;
+    let coeff_0 = evals[0] + evals[1] + evals[2] + evals[3];
+    let coeff_1 = roots_of_unity_inv[0] * (evals[0] - evals[1])
+        + roots_of_unity_inv[2] * (evals[2] - evals[3]);
+    let coeff_2 = roots_of_unity_inv[0] * (evals[0] + evals[1] - evals[2] - evals[3]);
+    let coeff_3 = roots_of_unity_inv[0] * (evals[0] - evals[1])
+        - roots_of_unity_inv[2] * (evals[2] - evals[3]);
+    (((coeff_3 * beta + coeff_2) * beta + coeff_1) * beta + coeff_0) * normalizing_factor
+}
+
+#[instrument(skip_all, level = "debug")]
+pub fn fold_quad<M: Matrix<F>, F: TwoAdicField>(m: M, beta: F) -> Vec<F> {
+    assert_eq!(m.width(), 4);
+    let log_arity = 2;
+    let g_inv = F::two_adic_generator(log2_strict_usize(m.height()) + log_arity).inverse();
+    let normalizing_factor = F::from_canonical_u32(1 << log_arity).inverse();
+
+    // TODO: vectorize this (after we have packed extension fields)
+
+    // successive powers of g_inv
+    let mut g_inv_powers = g_inv.powers().take(m.height()).collect_vec();
+    reverse_slice_index_bits(&mut g_inv_powers);
+
+    let root_of_unity = F::two_adic_generator(log_arity);
+    let mut roots_of_unity_inv = root_of_unity
+        .inverse()
+        .powers()
+        .take(1 << log_arity)
+        .collect_vec();
+    reverse_slice_index_bits(&mut roots_of_unity_inv);
+
+    m.par_rows()
+        .zip(g_inv_powers)
+        .map(|(mut row, g_inv_power)| {
+            let (r_0, r_1) = row.next_tuple().unwrap();
+            let (r_2, r_3) = row.next_tuple().unwrap();
+            fold_row_quad(
+                &[r_0, r_1, r_2, r_3],
+                &roots_of_unity_inv,
+                g_inv_power,
+                beta,
+                normalizing_factor,
+            )
+        })
+        .collect()
+}
+
+pub(crate) fn fold_row_large<F: TwoAdicField>(
+    evals: &mut [F],
+    roots_of_unity_inv: &[F],
+    g_inv_power: F,
+    beta: F,
+    normalizing_factor: F,
+    num_folds: usize,
+) -> F {
+    let h = 1 << num_folds;
+    for l in 0..num_folds {
+        let len = 1 << (l + 1);
+        (0..h).step_by(len).for_each(|i| {
+            let half_len = len >> 1;
+            for j in 0..half_len {
+                let idx_0 = i + j;
+                let idx_1 = idx_0 + half_len;
+                let u = evals[idx_0] + evals[idx_1];
+                let v = roots_of_unity_inv[idx_0 >> l] * (evals[idx_0] - evals[idx_1]);
+                evals[idx_0] = u;
+                evals[idx_1] = v;
+            }
+        });
+    }
+
+    let beta = beta * g_inv_power;
+    evals
+        .iter()
+        .rev()
+        .fold(F::ZERO, |acc, &eval| acc * beta + eval)
+        * normalizing_factor
+}
+
 /// Fold a polynomial by an arity higher than 2.
+#[instrument(skip_all, level = "debug")]
 pub fn fold<M: Matrix<F>, F: TwoAdicField>(m: M, beta: F, log_arity: usize) -> Vec<F> {
     assert_eq!(m.width(), 1 << log_arity);
     // Let h = 2^log_arity. Write a polynomial p(x) as sum_{i=0}^{h-1} x^i p_i(x^h).
@@ -69,42 +161,29 @@ pub fn fold<M: Matrix<F>, F: TwoAdicField>(m: M, beta: F, log_arity: usize) -> V
     // TODO: vectorize this (after we have packed extension fields)
 
     // successive powers of g_inv
-    let mut g_powers = g_inv.powers().take(m.height()).collect_vec();
-    reverse_slice_index_bits(&mut g_powers);
+    let mut g_inv_powers = g_inv.powers().take(m.height()).collect_vec();
+    reverse_slice_index_bits(&mut g_inv_powers);
 
     let root_of_unity = F::two_adic_generator(log_arity);
-    let mut roots_of_unity = root_of_unity
+    let mut roots_of_unity_inv = root_of_unity
         .inverse()
         .powers()
         .take(1 << log_arity)
         .collect_vec();
-    reverse_slice_index_bits(&mut roots_of_unity);
+    reverse_slice_index_bits(&mut roots_of_unity_inv);
 
-    let half_coeffs = roots_of_unity
-        .iter()
-        .map(|root| {
-            izip!(beta.powers().take(1 << (log_arity - 1)), root.powers(),)
-                .map(|(a, b)| normalizing_factor * a * b)
-                .collect_vec()
-        })
-        .collect_vec();
-
-    let beta_shift = beta.exp_power_of_2(log_arity - 1);
     m.par_rows()
-        .zip(g_powers)
-        .map(|(row, power)| {
-            let shift_even = F::ONE + beta_shift * power.exp_power_of_2(log_arity - 1);
-            let shift_odd = F::TWO - shift_even;
-            row.zip(half_coeffs.iter().enumerate())
-                .map(|(r, (i, coeff))| {
-                    let x = if i >> (log_arity - 1) & 1 == 0 {
-                        shift_even
-                    } else {
-                        shift_odd
-                    };
-                    r * x * izip!(coeff, power.powers()).map(|(a, b)| *a * b).sum()
-                })
-                .sum()
+        .zip(g_inv_powers)
+        .map(|(row, g_inv_power)| {
+            let mut row = row.collect_vec();
+            fold_row_large(
+                &mut row,
+                &roots_of_unity_inv,
+                g_inv_power,
+                beta,
+                normalizing_factor,
+                log_arity,
+            )
         })
         .collect::<Vec<_>>()
 }

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -12,10 +12,23 @@ use serde::{Deserialize, Serialize};
 pub struct FriProof<F: Field, M: Mmcs<F>, Witness, InputProof> {
     pub commit_phase_commits: Vec<M::Commitment>,
     pub query_proofs: Vec<QueryProof<F, M, InputProof>>,
+
+    // Fold each input so that it has the length of (2^log_arity * k) for some k.
+    pub normalize_phase_commits: Vec<(M::Commitment, usize)>,
+    pub normalize_query_proofs: Vec<NormalizeQueryProof<F, M>>,
+
     // This could become Vec<FC::Challenge> if this library was generalized to support non-constant
     // final polynomials.
     pub final_poly: F,
     pub pow_witness: Witness,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(bound = "")]
+pub struct NormalizeQueryProof<F: Field, M: Mmcs<F>> {
+    /// For each of the words that needs to be normalized, we do a single FRI fold step and open the
+    /// commitment at the queried index.
+    pub normalize_phase_openings: Vec<CommitPhaseProofStep<F, M>>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -33,10 +46,9 @@ pub struct QueryProof<F: Field, M: Mmcs<F>, InputProof> {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(bound = "")]
 pub struct CommitPhaseProofStep<F: Field, M: Mmcs<F>> {
-    /// The opening of the commit phase codeword at the sibling location.
-    // This may change to Vec<FC::Challenge> if the library is generalized to support other FRI
-    // folding arities besides 2, meaning that there can be multiple siblings.
-    pub sibling_value: F,
+    /// The opening of the commit phase codeword at the sibling locations (usually has length
+    /// 1<<config.log_arity).
+    pub sibling_values: Vec<F>,
 
     pub opening_proof: M::Proof,
 }

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -5,12 +5,14 @@ use core::iter;
 use itertools::{izip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
-use p3_field::{ExtensionField, Field};
+use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::log2_strict_usize;
 use tracing::{info_span, instrument};
 
-use crate::{CommitPhaseProofStep, FriConfig, FriGenericConfig, FriProof, QueryProof};
+use crate::{
+    CommitPhaseProofStep, FriConfig, FriGenericConfig, FriProof, NormalizeQueryProof, QueryProof,
+};
 
 #[instrument(name = "FRI prover", skip_all)]
 pub fn prove<G, Val, Challenge, M, Challenger>(
@@ -22,7 +24,7 @@ pub fn prove<G, Val, Challenge, M, Challenger>(
 ) -> FriProof<Challenge, M, Challenger::Witness, G::InputProof>
 where
     Val: Field,
-    Challenge: ExtensionField<Val>,
+    Challenge: ExtensionField<Val> + TwoAdicField,
     M: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     G: FriGenericConfig<Challenge>,
@@ -35,19 +37,58 @@ where
 
     let log_max_height = log2_strict_usize(inputs[0].len());
 
-    let commit_phase_result = commit_phase(g, config, inputs, challenger);
+    let normalize_phase_result = normalize_phase(g, config, &inputs, challenger);
+    let commit_phase_result = commit_phase(
+        g,
+        config,
+        normalize_phase_result.normalized_inputs,
+        challenger,
+    );
 
     let pow_witness = challenger.grind(config.proof_of_work_bits);
-
-    let query_proofs = info_span!("query phase").in_scope(|| {
+    let query_indices =
         iter::repeat_with(|| challenger.sample_bits(log_max_height + g.extra_query_index_bits()))
             .take(config.num_queries)
+            .collect_vec();
+
+    let normalize_query_proofs = info_span!("normalize query phase").in_scope(|| {
+        query_indices
+            .iter()
+            .map(|&index| NormalizeQueryProof {
+                normalize_phase_openings: normalize_phase_result
+                    .data
+                    .iter()
+                    .zip_eq(
+                        normalize_phase_result
+                            .commits
+                            .iter()
+                            .map(|(_, height)| *height),
+                    )
+                    .map(|(data, height)| {
+                        let shift = (height - config.log_blowup) % config.log_arity;
+                        answer_query_single_step(
+                            config,
+                            data,
+                            index >> g.extra_query_index_bits() >> (log_max_height - height),
+                            shift,
+                        )
+                    })
+                    .collect(),
+            })
+            .collect()
+    });
+
+    let query_proofs = info_span!("query phase").in_scope(|| {
+        let shift = (log_max_height - config.log_blowup) % config.log_arity;
+
+        query_indices
+            .into_iter()
             .map(|index| QueryProof {
                 input_proof: open_input(index),
                 commit_phase_openings: answer_query(
                     config,
                     &commit_phase_result.data,
-                    index >> g.extra_query_index_bits(),
+                    index >> g.extra_query_index_bits() >> shift,
                 ),
             })
             .collect()
@@ -55,6 +96,8 @@ where
 
     FriProof {
         commit_phase_commits: commit_phase_result.commits,
+        normalize_phase_commits: normalize_phase_result.commits,
+        normalize_query_proofs,
         query_proofs,
         final_poly: commit_phase_result.final_poly,
         pow_witness,
@@ -67,6 +110,64 @@ struct CommitPhaseResult<F: Field, M: Mmcs<F>> {
     final_poly: F,
 }
 
+#[instrument(name = "normalize phase", skip_all)]
+fn normalize_phase<G, Val, Challenge, M, Challenger>(
+    g: &G,
+    config: &FriConfig<M>,
+    inputs: &[Vec<Challenge>],
+    challenger: &mut Challenger,
+) -> NormalizePhaseResult<Challenge, M>
+where
+    Val: Field,
+    Challenge: TwoAdicField + ExtensionField<Val>,
+    M: Mmcs<Challenge>,
+    Challenger: CanObserve<M::Commitment> + FieldChallenger<Val>,
+    G: FriGenericConfig<Challenge>,
+{
+    let mut commits = vec![];
+    let mut data = vec![];
+
+    let mut normalized_inputs: [Option<Vec<Challenge>>; 32] = [const { None }; 32];
+    inputs.iter().for_each(|input| {
+        let log_height = log2_strict_usize(input.len());
+        let num_folds = (log_height - config.log_blowup) % config.log_arity;
+        let input = if log_height >= config.log_blowup
+            && (log_height - config.log_blowup) % config.log_arity == 0
+        {
+            input.clone()
+        } else {
+            let current = input.clone();
+            let leaves = RowMajorMatrix::new(current, 1 << num_folds);
+
+            let (commit, prover_data) = config.mmcs.commit_matrix(leaves.clone());
+            challenger.observe(commit.clone());
+            commits.push((commit, log_height));
+            data.push(prover_data);
+
+            let beta: Challenge = challenger.sample_ext_element();
+            g.fold_matrix(beta, leaves.as_view(), num_folds)
+        };
+        match &mut normalized_inputs[log_height - num_folds] {
+            Some(v) => {
+                v.iter_mut()
+                    .zip_eq(input)
+                    .for_each(|(v_elem, c_elem)| *v_elem += c_elem);
+            }
+            None => {
+                normalized_inputs[log_height - num_folds] = Some(input);
+            }
+        };
+    });
+
+    let normalized_inputs = normalized_inputs.into_iter().rev().flatten().collect();
+
+    NormalizePhaseResult {
+        commits,
+        data,
+        normalized_inputs,
+    }
+}
+
 #[instrument(name = "commit phase", skip_all)]
 fn commit_phase<G, Val, Challenge, M, Challenger>(
     g: &G,
@@ -76,25 +177,33 @@ fn commit_phase<G, Val, Challenge, M, Challenger>(
 ) -> CommitPhaseResult<Challenge, M>
 where
     Val: Field,
-    Challenge: ExtensionField<Val>,
+    Challenge: ExtensionField<Val> + TwoAdicField,
     M: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + CanObserve<M::Commitment>,
     G: FriGenericConfig<Challenge>,
 {
+    // By the time the prover gets to this phase, the `Some` inputs must all come from polynomials
+    // whose log-degree is a multiple of `config.log_arity`.
+    debug_assert!(inputs
+        .iter()
+        .all(|x| (log2_strict_usize(x.len()) - config.log_blowup) % config.log_arity == 0));
+
     let mut inputs_iter = inputs.into_iter().peekable();
     let mut folded = inputs_iter.next().unwrap();
     let mut commits = vec![];
     let mut data = vec![];
 
     while folded.len() > config.blowup() {
-        let leaves = RowMajorMatrix::new(folded, 2);
+        // A row of `leaves` is the information necessary to open the folded polynomial at a given
+        // index.
+        let leaves = RowMajorMatrix::new(folded.clone(), 1 << config.log_arity);
         let (commit, prover_data) = config.mmcs.commit_matrix(leaves);
         challenger.observe(commit.clone());
 
         let beta: Challenge = challenger.sample_ext_element();
         // We passed ownership of `current` to the MMCS, so get a reference to it
         let leaves = config.mmcs.get_matrices(&prover_data).pop().unwrap();
-        folded = g.fold_matrix(beta, leaves.as_view());
+        folded = g.fold_matrix(beta, leaves.as_view(), config.log_arity);
 
         commits.push(commit);
         data.push(prover_data);
@@ -119,6 +228,32 @@ where
     }
 }
 
+/// A function to answer a single step of the query phases.
+fn answer_query_single_step<F: Field, M: Mmcs<F>>(
+    config: &FriConfig<M>,
+    data: &M::ProverData<RowMajorMatrix<F>>,
+    index: usize,
+    log_num_leaves: usize,
+) -> CommitPhaseProofStep<F, M> {
+    let (mut opened_rows, opening_proof) = config.mmcs.open_batch(index >> log_num_leaves, data);
+
+    assert_eq!(opened_rows.len(), 1);
+    let opened_row = opened_rows.pop().unwrap();
+    assert_eq!(
+        opened_row.len(),
+        1 << log_num_leaves,
+        "Committed data should be in tuples of size arity."
+    );
+
+    let mut siblings = opened_row;
+    siblings.remove(index & ((1 << log_num_leaves) - 1));
+
+    CommitPhaseProofStep {
+        sibling_values: siblings,
+        opening_proof,
+    }
+}
+
 fn answer_query<F, M>(
     config: &FriConfig<M>,
     commit_phase_commits: &[M::ProverData<RowMajorMatrix<F>>],
@@ -128,24 +263,19 @@ where
     F: Field,
     M: Mmcs<F>,
 {
+    let log_arity = config.log_arity;
     commit_phase_commits
         .iter()
         .enumerate()
-        .map(|(i, commit)| {
-            let index_i = index >> i;
-            let index_i_sibling = index_i ^ 1;
-            let index_pair = index_i >> 1;
-
-            let (mut opened_rows, opening_proof) = config.mmcs.open_batch(index_pair, commit);
-            assert_eq!(opened_rows.len(), 1);
-            let opened_row = opened_rows.pop().unwrap();
-            assert_eq!(opened_row.len(), 2, "Committed data should be in pairs");
-            let sibling_value = opened_row[index_i_sibling % 2];
-
-            CommitPhaseProofStep {
-                sibling_value,
-                opening_proof,
-            }
+        .map(|(i, data)| {
+            let index_i = index >> (i * log_arity);
+            answer_query_single_step(config, data, index_i, log_arity)
         })
         .collect()
+}
+
+struct NormalizePhaseResult<F: Field, M: Mmcs<F>> {
+    commits: Vec<(M::Commitment, usize)>,
+    data: Vec<M::ProverData<RowMajorMatrix<F>>>,
+    normalized_inputs: Vec<Vec<F>>,
 }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -24,7 +24,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
 
 use crate::verifier::{self, FriError};
-use crate::{fold, fold_even_odd, prover, FriConfig, FriGenericConfig, FriProof};
+use crate::{
+    fold, fold_even_odd, fold_quad, fold_row_large, fold_row_quad, prover, FriConfig,
+    FriGenericConfig, FriProof,
+};
 
 #[derive(Debug)]
 pub struct TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
@@ -75,54 +78,56 @@ impl<F: TwoAdicField, InputProof, InputError: Debug> FriGenericConfig<F>
         log_height: usize,
         num_folds: usize,
         beta: F,
-        evals: Vec<F>,
+        mut evals: Vec<F>,
     ) -> F {
-        // Let h = 2^log_arity. Write a polynomial p(x) as sum_{i=0}^{h-1} x^i p_i(x^h).
-        // We seek a vector of evaluations of the polynomial p'(x) = sum_{i=1}^{h-1} beta^i p_i(x), given
-        // evaluations of p(x).
-        //
-        // Let z be an h-th root of unity. We use the formula:
-        // p_j(x) = 1/(h x^j) sum_{k=0}^{h-1} z^{-i*j}p(z^i*x), which is basically an inverse Fourier transform.
-        // Plugging this in to the expression for p'(x) gives:
-        // p'(x) = sum_{i,j=1}^{h-1} beta^i p(z^i * x) * beta^j * z^{-i*j} / (h x^j).
-
-        let g_inv = F::two_adic_generator(log_height + num_folds).inverse();
-        let normalizing_factor = F::from_canonical_u32(1 << num_folds).inverse();
-
-        // TODO: vectorize this (after we have packed extension fields)
-
-        // successive powers of g_inv
-        let g_power = g_inv.exp_u64(reverse_bits_len(index, log_height) as u64);
-
+        let g_power = F::two_adic_generator(log_height + num_folds)
+            .exp_u64(reverse_bits_len(index, log_height) as u64);
+        if num_folds == 1 {
+            let xs = F::two_adic_generator(1)
+                .shifted_powers(g_power)
+                .take(2)
+                .collect_vec();
+            let (e0, e1) = evals.into_iter().next_tuple().unwrap();
+            return e0 + (beta - xs[0]) * (e1 - e0) / (xs[1] - xs[0]);
+        }
+        // Let h = 2^log_arity, g_h be the root of unity that g_h^h = 1.
+        // p(X) = p_0 + X p_1 + X^2 p_2 + ... + X^(h-1) p_{h-1}.
+        // We have evals[i] = p(X * g^k) evaluated on g_h^i,
+        // where k = reverse_bits_len(index, log_height).
+        // From inverse FFT, we can compute p'(X) = p(X * g^k).
+        // And we want to compute p(beta) = p'(beta / g^k)
         let root_of_unity = F::two_adic_generator(num_folds);
-        let mut roots_of_unity = root_of_unity
+        let mut roots_of_unity_inv = root_of_unity
             .inverse()
             .powers()
             .take(1 << num_folds)
             .collect_vec();
-        reverse_slice_index_bits(&mut roots_of_unity);
+        reverse_slice_index_bits(&mut roots_of_unity_inv);
 
-        evals
-            .into_iter()
-            .zip(roots_of_unity.iter())
-            .map(|(r, root)| {
-                r * normalizing_factor
-                    * izip!(
-                        beta.powers().take(1 << num_folds),
-                        root.powers(),
-                        g_power.powers()
-                    )
-                    .map(|(a, b, c)| a * b * c)
-                    .sum()
-            })
-            .sum()
+        match num_folds {
+            2 => fold_row_quad(
+                &evals,
+                &roots_of_unity_inv,
+                g_power.inverse(),
+                beta,
+                F::from_canonical_u32(4).inverse(),
+            ),
+            _ => fold_row_large(
+                &mut evals,
+                &roots_of_unity_inv,
+                g_power.inverse(),
+                beta,
+                F::from_canonical_u32(1 << num_folds).inverse(),
+                num_folds,
+            ),
+        }
     }
 
     fn fold_matrix<M: Matrix<F>>(&self, beta: F, m: M, num_folds: usize) -> Vec<F> {
-        if num_folds == 1 {
-            fold_even_odd(m, beta)
-        } else {
-            fold(m, beta, num_folds)
+        match num_folds {
+            1 => fold_even_odd(m, beta),
+            2 => fold_quad(m, beta),
+            _ => fold(m, beta, num_folds),
         }
     }
 }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -2,6 +2,7 @@ use alloc::collections::BTreeMap;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
+use core::iter::once;
 use core::marker::PhantomData;
 
 use itertools::{izip, Itertools};
@@ -23,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
 
 use crate::verifier::{self, FriError};
-use crate::{prover, FriConfig, FriGenericConfig, FriProof};
+use crate::{fold, fold_even_odd, prover, FriConfig, FriGenericConfig, FriProof};
 
 #[derive(Debug)]
 pub struct TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
@@ -72,60 +73,57 @@ impl<F: TwoAdicField, InputProof, InputError: Debug> FriGenericConfig<F>
         &self,
         index: usize,
         log_height: usize,
+        num_folds: usize,
         beta: F,
-        evals: impl Iterator<Item = F>,
+        evals: Vec<F>,
     ) -> F {
-        let arity = 2;
-        let log_arity = 1;
-        let (e0, e1) = evals
-            .collect_tuple()
-            .expect("TwoAdicFriFolder only supports arity=2");
-        // If performance critical, make this API stateful to avoid this
-        // This is a bit more math than is necessary, but leaving it here
-        // in case we want higher arity in the future
-        let subgroup_start = F::two_adic_generator(log_height + log_arity)
-            .exp_u64(reverse_bits_len(index, log_height) as u64);
-        let mut xs = F::two_adic_generator(log_arity)
-            .shifted_powers(subgroup_start)
-            .take(arity)
-            .collect_vec();
-        reverse_slice_index_bits(&mut xs);
-        assert_eq!(log_arity, 1, "can only interpolate two points for now");
-        // interpolate and evaluate at beta
-        e0 + (beta - xs[0]) * (e1 - e0) / (xs[1] - xs[0])
-    }
+        // Let h = 2^log_arity. Write a polynomial p(x) as sum_{i=0}^{h-1} x^i p_i(x^h).
+        // We seek a vector of evaluations of the polynomial p'(x) = sum_{i=1}^{h-1} beta^i p_i(x), given
+        // evaluations of p(x).
+        //
+        // Let z be an h-th root of unity. We use the formula:
+        // p_j(x) = 1/(h x^j) sum_{k=0}^{h-1} z^{-i*j}p(z^i*x), which is basically an inverse Fourier transform.
+        // Plugging this in to the expression for p'(x) gives:
+        // p'(x) = sum_{i,j=1}^{h-1} beta^i p(z^i * x) * beta^j * z^{-i*j} / (h x^j).
 
-    fn fold_matrix<M: Matrix<F>>(&self, beta: F, m: M) -> Vec<F> {
-        // We use the fact that
-        //     p_e(x^2) = (p(x) + p(-x)) / 2
-        //     p_o(x^2) = (p(x) - p(-x)) / (2 x)
-        // that is,
-        //     p_e(g^(2i)) = (p(g^i) + p(g^(n/2 + i))) / 2
-        //     p_o(g^(2i)) = (p(g^i) - p(g^(n/2 + i))) / (2 g^i)
-        // so
-        //     result(g^(2i)) = p_e(g^(2i)) + beta p_o(g^(2i))
-        //                    = (1/2 + beta/2 g_inv^i) p(g^i)
-        //                    + (1/2 - beta/2 g_inv^i) p(g^(n/2 + i))
-        let g_inv = F::two_adic_generator(log2_strict_usize(m.height()) + 1).inverse();
-        let one_half = F::ONE.halve();
-        let half_beta = beta * one_half;
+        let g_inv = F::two_adic_generator(log_height + num_folds).inverse();
+        let normalizing_factor = F::from_canonical_u32(1 << num_folds).inverse();
 
         // TODO: vectorize this (after we have packed extension fields)
 
-        // beta/2 times successive powers of g_inv
-        let mut powers = g_inv
-            .shifted_powers(half_beta)
-            .take(m.height())
-            .collect_vec();
-        reverse_slice_index_bits(&mut powers);
+        // successive powers of g_inv
+        let g_power = g_inv.exp_u64(reverse_bits_len(index, log_height) as u64);
 
-        m.par_rows()
-            .zip(powers)
-            .map(|(mut row, power)| {
-                let (lo, hi) = row.next_tuple().unwrap();
-                (one_half + power) * lo + (one_half - power) * hi
+        let root_of_unity = F::two_adic_generator(num_folds);
+        let mut roots_of_unity = root_of_unity
+            .inverse()
+            .powers()
+            .take(1 << num_folds)
+            .collect_vec();
+        reverse_slice_index_bits(&mut roots_of_unity);
+
+        evals
+            .into_iter()
+            .zip(roots_of_unity.iter())
+            .map(|(r, root)| {
+                r * normalizing_factor
+                    * izip!(
+                        beta.powers().take(1 << num_folds),
+                        root.powers(),
+                        g_power.powers()
+                    )
+                    .map(|(a, b, c)| a * b * c)
+                    .sum()
             })
-            .collect()
+            .sum()
+    }
+
+    fn fold_matrix<M: Matrix<F>>(&self, beta: F, m: M, num_folds: usize) -> Vec<F> {
+        if num_folds == 1 {
+            fold_even_odd(m, beta)
+        } else {
+            fold(m, beta, num_folds)
+        }
     }
 }
 
@@ -366,7 +364,11 @@ where
         // Batch combination challenge
         let alpha: Challenge = challenger.sample_ext_element();
 
-        let log_global_max_height = proof.commit_phase_commits.len() + self.fri.log_blowup;
+        let log_global_max_height =
+            once(self.fri.log_arity * proof.commit_phase_commits.len() + self.fri.log_blowup)
+                .chain(proof.normalize_phase_commits.iter().map(|(_, l)| *l))
+                .max()
+                .unwrap();
 
         let g: TwoAdicFriGenericConfigForMmcs<Val, InputMmcs> =
             TwoAdicFriGenericConfig(PhantomData);

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -1,13 +1,13 @@
-use alloc::vec;
 use alloc::vec::Vec;
+use core::iter;
 
 use itertools::{izip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
-use p3_field::{ExtensionField, Field};
+use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::Dimensions;
 
-use crate::{CommitPhaseProofStep, FriConfig, FriGenericConfig, FriProof};
+use crate::{CommitPhaseProofStep, FriConfig, FriGenericConfig, FriProof, NormalizeQueryProof};
 
 #[derive(Debug)]
 pub enum FriError<CommitMmcsErr, InputError> {
@@ -16,6 +16,79 @@ pub enum FriError<CommitMmcsErr, InputError> {
     InputError(InputError),
     FinalPolyMismatch,
     InvalidPowWitness,
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+fn verify_normalization_phase<F, G, M>(
+    g: &G,
+    config: &FriConfig<M>,
+    normalize_phase_commits: &[(M::Commitment, usize)],
+    index: usize,
+    normalize_proof: &NormalizeQueryProof<F, M>,
+    betas: &[F],
+    reduced_openings: &[(usize, F)],
+    log_max_height: usize,
+) -> Result<Vec<(usize, F)>, FriError<M::Error, G::InputError>>
+where
+    F: TwoAdicField,
+    G: FriGenericConfig<F>,
+    M: Mmcs<F>,
+{
+    // Populate the return value with zeros, or with the reduced openings at the correct indices.
+    let mut new_openings = [F::ZERO; 32];
+    reduced_openings
+        .iter()
+        .cloned()
+        .for_each(|(log_height, reduced_opening)| {
+            if log_height >= config.log_blowup
+                && (log_height - config.log_blowup) % config.log_arity == 0
+            {
+                new_openings[log_height] = reduced_opening
+            }
+        });
+
+    for ((commit, log_height), step, reduced_opening, beta) in izip!(
+        normalize_phase_commits.iter(),
+        normalize_proof.normalize_phase_openings.iter(),
+        reduced_openings.iter().filter(|(log_height, _)| {
+            (log_height >= &config.log_blowup)
+                && (log_height - config.log_blowup) % config.log_arity != 0
+        }),
+        betas
+    ) {
+        debug_assert_eq!(*log_height, reduced_opening.0);
+        let num_folds = (log_height - config.log_blowup) % config.log_arity;
+        let log_folded_height = log_height - num_folds;
+
+        // Verify the fold step and update the new openings. `folded_height` is the closest
+        // "normalized" height to `log_height`. `step` and `commit` give us the information necessary
+        // to fold the unnormalized opening from `log_height` multiple steps down to `folded_height`.
+        new_openings[log_folded_height] += verify_fold_step(
+            g,
+            reduced_opening.1,
+            *beta,
+            num_folds,
+            step,
+            commit,
+            index >> (log_max_height - log_height),
+            *log_height - num_folds,
+            &config.mmcs,
+        )?;
+    }
+
+    Ok(new_openings
+        .into_iter()
+        .enumerate()
+        .rev()
+        .filter_map(|(i, opening)| {
+            if !opening.is_zero() {
+                Some((i, opening))
+            } else {
+                None
+            }
+        })
+        .collect_vec())
 }
 
 pub fn verify<G, Val, Challenge, M, Challenger>(
@@ -27,11 +100,21 @@ pub fn verify<G, Val, Challenge, M, Challenger>(
 ) -> Result<(), FriError<M::Error, G::InputError>>
 where
     Val: Field,
-    Challenge: ExtensionField<Val>,
+    Challenge: TwoAdicField + ExtensionField<Val>,
     M: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     G: FriGenericConfig<Challenge>,
 {
+    // The prover sampled the normalize betas first, so we need to sample these first here.
+    let normalize_betas: Vec<Challenge> = proof
+        .normalize_phase_commits
+        .iter()
+        .map(|(comm, _)| {
+            challenger.observe(comm.clone());
+            challenger.sample_ext_element()
+        })
+        .collect();
+
     let betas: Vec<Challenge> = proof
         .commit_phase_commits
         .iter()
@@ -51,9 +134,19 @@ where
         return Err(FriError::InvalidPowWitness);
     }
 
-    let log_max_height = proof.commit_phase_commits.len() + config.log_blowup;
+    // The max height passed into `verify_challenges` can be computed from the config and the number
+    // of commit phase steps.
+    let log_max_normalized_height =
+        config.log_arity * proof.commit_phase_commits.len() + config.log_blowup;
 
-    for qp in &proof.query_proofs {
+    // The overall max height is either the maximum of the heights associated with the normalize
+    // phase commits, or it's the max normalized height.
+    let log_max_height = iter::once(log_max_normalized_height)
+        .chain(proof.normalize_phase_commits.iter().map(|(_, h)| *h))
+        .max()
+        .unwrap();
+
+    for (qp, np) in izip!(&proof.query_proofs, &proof.normalize_query_proofs) {
         let index = challenger.sample_bits(log_max_height + g.extra_query_index_bits());
         let ro = open_input(index, &qp.input_proof).map_err(FriError::InputError)?;
 
@@ -62,17 +155,31 @@ where
             "reduced openings sorted by height descending"
         );
 
+        // The function `verify_query` expects its `reduced_openings` argument to have a "normalized"
+        // shape (all non-zero entries must be at indices that are multiples of `config.log_arity`
+        // added to the log blowup factor), so we first normalize the openings.
+        let normalized_openings = verify_normalization_phase(
+            g,
+            config,
+            &proof.normalize_phase_commits,
+            index >> g.extra_query_index_bits(),
+            np,
+            &normalize_betas,
+            &ro,
+            log_max_height,
+        )?;
+
         let folded_eval = verify_query(
             g,
             config,
-            index >> g.extra_query_index_bits(),
+            index >> (log_max_height - log_max_normalized_height) >> g.extra_query_index_bits(),
             izip!(
                 &betas,
                 &proof.commit_phase_commits,
                 &qp.commit_phase_openings
             ),
-            ro,
-            log_max_height,
+            betas.len(),
+            normalized_openings,
         )?;
 
         if folded_eval != proof.final_poly {
@@ -94,53 +201,93 @@ fn verify_query<'a, G, F, M>(
     config: &FriConfig<M>,
     mut index: usize,
     steps: impl Iterator<Item = CommitStep<'a, F, M>>,
+    step_len: usize,
     reduced_openings: Vec<(usize, F)>,
-    log_max_height: usize,
 ) -> Result<F, FriError<M::Error, G::InputError>>
 where
-    F: Field,
+    F: TwoAdicField,
     M: Mmcs<F> + 'a,
     G: FriGenericConfig<F>,
 {
-    let mut folded_eval = F::ZERO;
-    let mut ro_iter = reduced_openings.into_iter().peekable();
+    // Deduce the max normalized height as in `verify_shape_and_sample_challenges`.
+    let log_max_normalized_height = config.log_arity * step_len + config.log_blowup;
 
-    for (log_folded_height, (&beta, comm, opening)) in izip!((0..log_max_height).rev(), steps) {
-        if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height + 1) {
-            folded_eval += ro;
-        }
-
-        let index_sibling = index ^ 1;
-        let index_pair = index >> 1;
-
-        let mut evals = vec![folded_eval; 2];
-        evals[index_sibling % 2] = opening.sibling_value;
-
-        let dims = &[Dimensions {
-            width: 2,
-            height: 1 << log_folded_height,
-        }];
-        config
-            .mmcs
-            .verify_batch(
-                comm,
-                dims,
-                index_pair,
-                &[evals.clone()],
-                &opening.opening_proof,
-            )
-            .map_err(FriError::CommitPhaseMmcsError)?;
-
-        index = index_pair;
-
-        folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
+    // Check that the reduced openings are in a "normalized" shape.
+    for (_, ro) in reduced_openings.iter().filter(|(log_height, _)| {
+        (log_height >= &config.log_blowup)
+            && (log_height - config.log_blowup) % config.log_arity != 0
+    }) {
+        assert!(ro.is_zero());
     }
 
-    debug_assert!(index < config.blowup(), "index was {}", index);
-    debug_assert!(
-        ro_iter.next().is_none(),
-        "verifier reduced_openings were not in descending order?"
-    );
+    let mut ro_iter = reduced_openings.into_iter().peekable();
+    let mut folded_eval = ro_iter.next().map_or(F::ZERO, |(_, eval)| eval);
+
+    for (log_folded_height, (&beta, comm, step)) in izip!(
+        (config.log_blowup..(log_max_normalized_height + 1).saturating_sub(config.log_arity))
+            .rev()
+            .step_by(config.log_arity),
+        steps
+    ) {
+        folded_eval = verify_fold_step(
+            g,
+            folded_eval,
+            beta,
+            config.log_arity,
+            step,
+            comm,
+            index,
+            log_folded_height,
+            &config.mmcs,
+        )?;
+        index >>= config.log_arity;
+
+        if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height) {
+            folded_eval += ro;
+        }
+    }
 
     Ok(folded_eval)
+}
+
+/// Verify a single FRI fold consistency check.
+///
+/// The functions `verify_query` and `verify_normalization_phase` both call this function.
+#[allow(clippy::too_many_arguments)]
+fn verify_fold_step<G: FriGenericConfig<F>, F: TwoAdicField, M: Mmcs<F>>(
+    g: &G,
+    folded_eval: F,
+    beta: F,
+    num_folds: usize,
+    step: &CommitPhaseProofStep<F, M>,
+    commit: &M::Commitment,
+    index: usize,
+    log_folded_height: usize,
+    mmcs: &M,
+) -> Result<F, FriError<M::Error, G::InputError>> {
+    let mask = (1 << num_folds) - 1;
+    let index_self_in_siblings = index & mask;
+    let index_set = index >> num_folds;
+
+    let mut evals: Vec<F> = step.sibling_values.clone();
+    evals.insert(index_self_in_siblings, folded_eval);
+
+    // `commit` should be a commitment to a matrix with 2^num_folds columns and 2^log_folded_height
+    // rows.
+    debug_assert_eq!(evals.len(), 1 << num_folds);
+    let dims = &[Dimensions {
+        width: 1 << num_folds,
+        height: 1 << (log_folded_height),
+    }];
+
+    mmcs.verify_batch(
+        commit,
+        dims,
+        index_set,
+        &[evals.clone()],
+        &step.opening_proof,
+    )
+    .map_err(FriError::CommitPhaseMmcsError)?;
+
+    Ok(g.fold_row(index_set, log_folded_height, num_folds, beta, evals))
 }

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -1,6 +1,7 @@
 use core::cmp::Reverse;
 use std::marker::PhantomData;
 
+use itertools::Itertools;
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{CanSampleBits, DuplexChallenger, FieldChallenger};
 use p3_commit::ExtensionMmcs;
@@ -29,30 +30,41 @@ type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
 type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type MyFriConfig = FriConfig<ChallengeMmcs>;
 
-fn get_ldt_for_testing<R: Rng>(rng: &mut R) -> (Perm, MyFriConfig) {
+fn get_ldt_for_testing<R: Rng>(
+    rng: &mut R,
+    log_arity: usize,
+    log_blowup: usize,
+) -> (Perm, MyFriConfig) {
     let perm = Perm::new_from_rng_128(rng);
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));
     let fri_config = FriConfig {
-        log_blowup: 1,
+        log_blowup,
         num_queries: 10,
         proof_of_work_bits: 8,
         mmcs,
+        log_arity,
     };
     (perm, fri_config)
 }
 
-fn do_test_fri_ldt<R: Rng>(rng: &mut R) {
-    let (perm, fc) = get_ldt_for_testing(rng);
+fn do_test_fri_ldt<R: Rng>(
+    rng: &mut R,
+    test_shapes: &[usize],
+    log_arity: usize,
+    log_blowup: usize,
+) {
+    let (perm, fc) = get_ldt_for_testing(rng, log_arity, log_blowup);
     let dft = Radix2Dit::default();
 
     let shift = Val::GENERATOR;
 
-    let ldes: Vec<RowMajorMatrix<Val>> = (3..10)
+    let ldes: Vec<RowMajorMatrix<Val>> = test_shapes
+        .iter()
         .map(|deg_bits| {
             let evals = RowMajorMatrix::<Val>::rand_nonzero(rng, 1 << deg_bits, 16);
-            let mut lde = dft.coset_lde_batch(evals, 1, shift);
+            let mut lde = dft.coset_lde_batch(evals, log_blowup, shift);
             reverse_matrix_index_bits(&mut lde);
             lde
         })
@@ -88,6 +100,7 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R) {
 
         let log_max_height = log2_strict_usize(input[0].len());
 
+        let now = std::time::Instant::now();
         let proof = prover::prove(
             &TwoAdicFriGenericConfig::<Vec<(usize, Challenge)>, ()>(PhantomData),
             &fc,
@@ -103,6 +116,11 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R) {
                 ro.sort_by_key(|(lh, _)| Reverse(*lh));
                 ro
             },
+        );
+        println!(
+            "Prover time at log_arity {}: {:?}",
+            log_arity,
+            now.elapsed().as_secs_f32()
         );
 
         (proof, chal.sample_bits(8))
@@ -131,6 +149,20 @@ fn test_fri_ldt() {
     // FRI is kind of flaky depending on indexing luck
     for i in 0..4 {
         let mut rng = ChaCha20Rng::seed_from_u64(i);
-        do_test_fri_ldt(&mut rng);
+        do_test_fri_ldt(&mut rng, (3..10).collect_vec().as_slice(), 1, 1);
+    }
+}
+
+#[test]
+fn test_fri_higher_arity() {
+    // FRI is kind of flaky depending on indexing luck
+    for i in 0..4 {
+        let mut rng = ChaCha20Rng::seed_from_u64(i);
+        do_test_fri_ldt(&mut rng, &[2, 3, 4], 2, 1);
+        do_test_fri_ldt(&mut rng, &[2, 4, 6, 8], 3, 1);
+        do_test_fri_ldt(&mut rng, &[2, 4, 6, 7], 3, 1);
+        do_test_fri_ldt(&mut rng, &[2, 4, 6, 8, 10], 4, 1);
+        do_test_fri_ldt(&mut rng, &[0, 2, 4, 6, 8], 3, 4);
+        do_test_fri_ldt(&mut rng, &[0, 4], 3, 4);
     }
 }

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -168,7 +168,7 @@ mod babybear_fri_pcs {
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
     type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 
-    fn get_pcs(log_blowup: usize) -> (MyPcs, Challenger) {
+    fn get_pcs(log_blowup: usize, log_arity: usize) -> (MyPcs, Challenger) {
         let perm = Perm::new_from_rng_128(&mut seeded_rng());
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm.clone());
@@ -178,6 +178,7 @@ mod babybear_fri_pcs {
 
         let fri_config = FriConfig {
             log_blowup,
+            log_arity,
             num_queries: 10,
             proof_of_work_bits: 8,
             mmcs: challenge_mmcs,
@@ -188,10 +189,10 @@ mod babybear_fri_pcs {
     }
 
     mod blowup_1 {
-        make_tests_for_pcs!(super::get_pcs(1));
+        make_tests_for_pcs!(super::get_pcs(1, 1));
     }
     mod blowup_2 {
-        make_tests_for_pcs!(super::get_pcs(2));
+        make_tests_for_pcs!(super::get_pcs(2, 1));
     }
 }
 
@@ -233,6 +234,7 @@ mod m31_fri_pcs {
             num_queries: 10,
             proof_of_work_bits: 8,
             mmcs: challenge_mmcs,
+            log_arity: 1,
         };
         let pcs = Pcs {
             mmcs: val_mmcs,

--- a/keccak-air/examples/prove_baby_bear_keccak.rs
+++ b/keccak-air/examples/prove_baby_bear_keccak.rs
@@ -55,6 +55,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -57,6 +57,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -57,6 +57,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -57,6 +57,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -59,6 +59,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -57,6 +57,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_koala_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_koala_bear_poseidon2.rs
@@ -59,6 +59,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_m31_keccak.rs
+++ b/keccak-air/examples/prove_m31_keccak.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_m31_poseidon2.rs
+++ b/keccak-air/examples/prove_m31_poseidon2.rs
@@ -54,6 +54,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
@@ -105,6 +105,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1, // TODO: Should this be 3? Why is it working?
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -105,6 +105,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -113,6 +113,7 @@ fn prove_and_verify() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_poseidon2.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_poseidon2.rs
@@ -97,6 +97,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
@@ -100,6 +100,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = FriConfig {
         log_blowup: 1,
+        log_arity: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -122,6 +122,7 @@ fn test_public_value_impl(n: usize, x: u64) {
     let trace = generate_trace_rows::<Val>(0, 1, n);
     let fri_config = FriConfig {
         log_blowup: 2,
+        log_arity: 1,
         num_queries: 28,
         proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
@@ -161,6 +162,7 @@ fn test_incorrect_public_value() {
     let dft = Dft::default();
     let fri_config = FriConfig {
         log_blowup: 2,
+        log_arity: 1,
         num_queries: 28,
         proof_of_work_bits: 8,
         mmcs: challenge_mmcs,

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -216,6 +216,7 @@ fn do_test_bb_twoadic(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
 
     let fri_config = FriConfig {
         log_blowup,
+        log_arity: 1,
         num_queries: 40,
         proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
@@ -276,6 +277,7 @@ fn do_test_m31_circle(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
 
     let fri_config = FriConfig {
         log_blowup,
+        log_arity: 1,
         num_queries: 40,
         proof_of_work_bits: 8,
         mmcs: challenge_mmcs,


### PR DESCRIPTION
Add an optimization to the `g.fold_matrix` algorithm, here is the benchmark:

| num_vars | field            | fold/log(arity)= 1 | fold/log(arity)= 2 | fold/log(arity)= 4 |
|----------|------------------|--------------------|--------------------|--------------------|
| 20       | BabyBear         | 5.4034 ms          | 5.0623 ms          | 10.269 ms          |
| 20       | Goldilocks       | 5.5285 ms          | 6.0533 ms          | 10.222 ms          |
| 20       | Complex_Mersenne | 10.443 ms          | 12.134 ms          | 20.865 ms          |
| 24       | BabyBear         | 95.785 ms          | 87.998 ms          | 160.74 ms          |
| 24       | Goldilocks       | 115.27 ms          | 102.21 ms          | 161.39 ms          |
| 24       | Complex_Mersenne | 183.88 ms          | 202.51 ms          | 332.30 ms          |

The updated PCS benchmark:
| shapes               | log(arity) | prove     | verify    | proof_size |
|----------------------|------------|-----------|-----------|------------|
| [16, 17, 18, 19, 20] | 1          | 1.6907 s  | 26.705 ms | 733.49 KB  |
| [16, 17, 18, 19, 20] | 2          | 1.3767 s  | 18.550 ms | 508.25 KB  |
| [16, 17, 18, 19, 20] | 4          | 1.3905 s  | 17.136 ms | 461.26 KB  |
| [12, 14, 16, 18, 20] | 1          | 1.7492 s  | 26.105 ms | 733.49 KB  |
| [12, 14, 16, 18, 20] | 2          | 978.11 ms | 14.163 ms | 389.43 KB  |
| [12, 14, 16, 18, 20] | 4          | 915.17 ms | 14.215 ms | 386.22 KB  |
| [4, 8, 12, 16, 20]   | 1          | 1.6329 s  | 25.525 ms | 733.49 KB  |
| [4, 8, 12, 16, 20]   | 2          | 903.22 ms | 13.974 ms | 389.43 KB  |
| [4, 8, 12, 16, 20]   | 4          | 792.44 ms | 10.214 ms | 279.89 KB  |